### PR TITLE
Add codiceIPA to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -95,6 +95,8 @@ it:
     cie: false
     pagopa: true
     spid: false
+  riuso:
+    codiceIPA: r_marche
 legal:
   license: GPL-2.0-or-later
 localisation:


### PR DESCRIPTION
Buongiorno @XXG1G4XX @ilkosta, 
questa PR:
* aggiunge il campo `codiceIPA` relativo a Regione Marche nel file `publiccode.yml`.

Resto a disposizione.
Grazie!